### PR TITLE
Add static files volume to web container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,4 +29,4 @@ postgres:
 dbstorage:
   image: postgres:latest
   volumes:
-    - data:/var/lib/postgresql
+    - /var/lib/postgresql/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ web:
   image: radioco/web
   links:
     - postgres:postgres
+  volumes:
+    - /usr/src/app/radio/static
   env_file: web/env
   command: radio/configs/docker/docker-entrypoint.sh
 
@@ -11,8 +13,6 @@ nginx:
   image: radioco/nginx
   ports:
     - "80:80"
-  volumes:
-    - /www/static
   volumes_from:
     - web
   links:


### PR DESCRIPTION
Mariona/Pablo pairing:

Web container needs to declare the static assets folder as a volume to allow nginx container to import/mount the volume and server the static assets

Fixed issue "postgres database not found" by exposing through dbstorage the postgres data folder.